### PR TITLE
Added gamble to balance market

### DIFF
--- a/kala.js
+++ b/kala.js
@@ -3,7 +3,8 @@ let loadedState = JSON.parse(localStorage.getItem("state"))
 let state = loadedState || {
     money: 0,
     fish: 0,
-    market: 1.5,
+    market: 1,
+    marketLimit: 1,
     fisherman: 0,
     boat: 1,
     beach: 0,
@@ -24,7 +25,7 @@ setInterval(() => {
 }, 5000);
 
 let prices = {
-    market: 222,
+    market: 1,
     fisherman: 10,
     boat: 800,
     beach: 9998,
@@ -33,13 +34,15 @@ let prices = {
 }
 
 let multipliers = {
-    market: 5,
+    market: 1,
     fisherman: 0.3,
     boat: 0.3,
     beach: 0.3,
     bottle: 0.3,
     taxi: 0.3,
 }
+
+let marketLimitDom = document.querySelector("#state-marketLimit");
 
 function calculatePrice(itemName) {
     return prices[itemName] + prices[itemName] * multipliers[itemName] * state[itemName];
@@ -60,23 +63,29 @@ fishing = () => {
 }
 a = setInterval(fishing, Math.max(10, 100 / state.boat));
 function sellFish() {
-    state.money += (state.fish * state.market) + (state.greyfish * state.market * 12)
+    state.money += (state.fish * state.market/2) + (state.greyfish * state.market/2 * 12)
     state.fish = 0;
     state.greyfish = 0;
     fishDisplay.textContent = state.fish;
 }
 
 function buyMarket() {
-    // TODO näita kuidas need kaks rida teha funktsiooniks
     let itemName = "market";
-    let price = calculatePrice(itemName);
+    let price = prices[itemName] * state[itemName];
     if (state.money >= price) {
+        if (state.market >= marketLimitDom.value)
+            return;
+
         state.market++;
-        state.market = state.market * 1.2;
         state.money -= price;
-        console.log("Sa arendasid enda turgu:", state.market);
-        let marketDisplay = document.querySelector("#market");
-        marketDisplay.textContent = state.market;
+
+        if (Math.random() < 0.5) {
+            state.market = 1;
+            console.log("Turul oli kriis, kõik su turundusstrateegiad on mõttetud, pead alustama otsast peale.");
+        } else {
+            console.log("Sa arendasid enda turgu:", state.market);
+        }
+        updateDisplay()
     } else {
         alert("sul on vaja " + price + " münti");
     }

--- a/site.html
+++ b/site.html
@@ -38,7 +38,8 @@
             <div class="card" id="market-card" style="background-color: transparent;">
                 <h2>Market: <span id="state-market">1.3</span> 🏪</h2>
                 <h2>Market Price <span id="price-market">200</span> 💰</h2>
-                <button onclick="buyMarket()">Buy Market Upgrade 🏪</button>
+                <button onclick="buyMarket()">Buy Market Upgrade 🏪<br/>(50% chance to reset to 1)</button>
+                <input class="btn" type="number" id="state-marketLimit" value="5" min="1" max="100" title="Auto-clicker safety helper, disables buy button when reaches market limit">
             </div>
             <div class="card" id="boat-card" style="background-color: transparent;">
                 <h2>Boats: <span id="state-boat">0</span>/10</h2>

--- a/style.css
+++ b/style.css
@@ -55,7 +55,7 @@ footer {
     margin-top: 20px;
 }
 
-button {
+button, .btn {
     background-color: #546E7A;
     color: #ffffff;
     border: none;
@@ -65,6 +65,6 @@ button {
     margin-top: 10px;
 }
 
-button:hover {
+button:hover, .btn:hover {
     background-color: #455A64;
 }


### PR DESCRIPTION
Market multiplies fish selling price, which is currently very overpowered. I added a gamble feature to market buy button. Market is very cheap: $1 * total amount of markets you have. So $1, $2, $3, $4, etc for every level. But you have 50% change that level drops back to 1 and you have to start over.

It could take $2k already for level 7 boost, but if you get greedy and fail, it may take another 2-5k to get back to level 7.